### PR TITLE
Implement password reset flow

### DIFF
--- a/Backend/index.js
+++ b/Backend/index.js
@@ -443,6 +443,151 @@ app.post('/api/login', (req, res) => {
   });
 });
 
+// Enviar enlace para restablecer contraseña
+app.post('/api/forgot-password', (req, res) => {
+  const { emailOrUsername } = req.body;
+  if (!emailOrUsername) {
+    return res.status(400).json({ error: 'Email or username required' });
+  }
+
+  pool.getConnection((err, connection) => {
+    if (err) {
+      console.error('Error al obtener la conexión:', err);
+      return res.status(500).json({ error: 'Error al obtener la conexión.' });
+    }
+
+    const query = 'SELECT id, email FROM user_account WHERE email = ? OR username = ?';
+    connection.query(query, [emailOrUsername, emailOrUsername], async (err, results) => {
+      connection.release();
+      if (err) {
+        console.error('Error al buscar el usuario:', err);
+        return res.status(500).json({ error: 'Error al buscar el usuario.' });
+      }
+
+      if (results.length === 0) {
+        return res.status(200).json({ notFound: true });
+      }
+
+      const { id, email } = results[0];
+      const resetToken = jwt.sign({ id }, process.env.JWT_SECRET, { expiresIn: '1h' });
+      const url = `${process.env.BASE_URL}/reset-password?token=${resetToken}`;
+
+      try {
+        await transporter.sendMail({
+          from: '"Wisdom" <wisdom.helpcontact@gmail.com>',
+          to: email,
+          subject: 'Reset your password for Wisdom',
+          attachments: [
+            { filename: 'wisdom.png', path: path.join(__dirname, 'assets', 'wisdom.png'), cid: 'wisdomLogo' },
+            { filename: 'instagram.png', path: path.join(__dirname, 'assets', 'instagram.png'), cid: 'instagramLogo' },
+            { filename: 'twitter.png', path: path.join(__dirname, 'assets', 'twitter.png'), cid: 'twitterLogo' }
+          ],
+          html: `
+          <table width="100%" cellpadding="0" cellspacing="0" style="background:#ffffff;font-family:Inter,sans-serif;color:#111827;">
+            <tr>
+              <td align="center" style="padding:48px 24px;">
+                <div style="font-size:24px;font-weight:600;letter-spacing:.6px;margin-bottom:32px;">
+                  WISDOM<sup style="font-size:12px;vertical-align:top;">®</sup>
+                </div>
+                <h1 style="font-size:30px;font-weight:500;margin-bottom:16px;">
+                  Reset your password for Wisdom
+                </h1>
+                <p style="font-size:16px;line-height:1.55;max-width:420px;margin:0 auto 50px;">
+                  It looks like you lost your password. To pick a new one, hit the button below
+                </p>
+                <a href="${url}" style="display:inline-block;padding:22px 100px;background:#f3f3f3;border-radius:14px;text-decoration:none;font-size:14px;font-weight:600;color:#111827;">
+                  Reset Password
+                </a>
+                <hr style="border:none;height:1px;background-color:#f3f4f6;margin:70px 0;width:100%;" />
+                <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 auto 24px;">
+                  <tr>
+                    <td style="padding:0 5px;">
+                      <a href="https://wisdom-web.vercel.app/" aria-label="Wisdom web" style="display:flex;width:32px;height:32px;background:#f3f4f6;border-radius:50%;text-decoration:none;justify-content:center;align-items:center;">
+                        <img src="cid:wisdomLogo" alt="Wisdom" style="display:block;margin:auto;max-width:18px;max-height:18px;object-fit:contain;" />
+                      </a>
+                    </td>
+                    <td style="padding:0 5px;">
+                      <a href="https://www.instagram.com/wisdom__app/" aria-label="Instagram" style="display:flex;width:32px;height:32px;background:#f3f4f6;border-radius:50%;text-decoration:none;justify-content:center;align-items:center;">
+                        <img src="cid:instagramLogo" alt="Instagram" width="18" height="18" style="display:block;margin:auto;" />
+                      </a>
+                    </td>
+                    <td style="padding:0 0px;">
+                      <a href="https://x.com/wisdom_entity" aria-label="Twitter" style="display:flex;width:32px;height:32px;background:#f3f4f6;border-radius:50%;text-decoration:none;justify-content:center;align-items:center;">
+                        <img src="cid:twitterLogo" alt="Twitter" width="18" height="18" style="display:block;margin:auto;" />
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+                <div style="font-size:12px;color:#6b7280;line-height:1.4;text-decoration:none;">
+                  <a href="#" style="color:#6b7280;text-decoration:none;">Privacy Policy</a>
+                  &nbsp;·&nbsp;
+                  <a href="#" style="color:#6b7280;text-decoration:none;">Terms of Service</a>
+                  <br /><br />
+                  Mataró, BCN, 08304
+                  <br /><br />
+                  This email was sent to ${email}
+                </div>
+              </td>
+            </tr>
+          </table>`
+        });
+      } catch (mailErr) {
+        console.error('Error al enviar el correo de restablecimiento:', mailErr);
+      }
+
+      res.json({ message: 'Reset email sent' });
+    });
+  });
+});
+
+// Restablecer contraseña con token
+app.post('/api/reset-password', async (req, res) => {
+  const { token, newPassword } = req.body;
+  if (!token || !newPassword) {
+    return res.status(400).json({ error: 'Token and new password required' });
+  }
+
+  jwt.verify(token, process.env.JWT_SECRET, async (err, decoded) => {
+    if (err) {
+      return res.status(400).json({ error: 'Invalid or expired token' });
+    }
+
+    const userId = decoded.id;
+    pool.getConnection(async (connErr, connection) => {
+      if (connErr) {
+        console.error('Error al obtener la conexión:', connErr);
+        return res.status(500).json({ error: 'Error al obtener la conexión.' });
+      }
+
+      try {
+        const hashed = await bcrypt.hash(newPassword, 10);
+        connection.query('UPDATE user_account SET password = ? WHERE id = ?', [hashed, userId], (err) => {
+          if (err) {
+            connection.release();
+            console.error('Error al actualizar la contraseña:', err);
+            return res.status(500).json({ error: 'Error al actualizar la contraseña.' });
+          }
+
+          connection.query('SELECT id, email, username, first_name, surname, profile_picture, is_professional, language FROM user_account WHERE id = ?', [userId], (err, results) => {
+            connection.release();
+            if (err || results.length === 0) {
+              return res.status(500).json({ error: 'Error al obtener el usuario.' });
+            }
+
+            const user = results[0];
+            const loginToken = jwt.sign({ id: userId }, process.env.JWT_SECRET, { expiresIn: '1h' });
+            res.json({ message: 'Password reset successfully', user, token: loginToken });
+          });
+        });
+      } catch (hashErr) {
+        connection.release();
+        console.error('Error al hashear la nueva contraseña:', hashErr);
+        res.status(500).json({ error: 'Error al procesar la solicitud.' });
+      }
+    });
+  });
+});
+
 // Proteger las rutas siguientes con JWT
 app.use(authenticateToken);
 

--- a/Frontend/Wisdom_expo/languages/ar.json
+++ b/Frontend/Wisdom_expo/languages/ar.json
@@ -119,6 +119,8 @@
     "confirm_new_password": "تأكيد كلمة المرور الجديدة",
     "type_it_again": "اكتبها مرة أخرى",
     "safe_and_login": "احفظ وسجّل الدخول",
+    "passwords_do_not_match": "كلمات المرور غير متطابقة.",
+    "reset_token_error": "حدثت مشكلة أثناء إعادة تعيين كلمة المرور.",
     "stay_informed": "ابق على اطلاع",
     "notifications_subtitle": "تلقي المعلومات والتذكيرات حول خدماتك",
     "allow": "السماح",

--- a/Frontend/Wisdom_expo/languages/ca.json
+++ b/Frontend/Wisdom_expo/languages/ca.json
@@ -119,6 +119,8 @@
     "confirm_new_password": "Confirma la nova contrasenya",
     "type_it_again": "Torna-la a escriure",
     "safe_and_login": "Desa i inicia sessió",
+    "passwords_do_not_match": "Les contrasenyes no coincideixen.",
+    "reset_token_error": "S'ha produït un problema en restablir la contrasenya.",
     "stay_informed": "Mantén-te informat",
     "notifications_subtitle": "Rep informació i recordatoris dels teus serveis",
     "allow": "Permetre",

--- a/Frontend/Wisdom_expo/languages/en.json
+++ b/Frontend/Wisdom_expo/languages/en.json
@@ -119,6 +119,8 @@
     "confirm_new_password": "Confirm new password",
     "type_it_again": "Type it again",
     "safe_and_login": "Safe and Login",
+    "passwords_do_not_match": "Passwords do not match.",
+    "reset_token_error": "There was a problem resetting your password.",
     "stay_informed": "Stay informed",
     "notifications_subtitle": "Receive information and reminders of your services",
     "allow": "Allow",

--- a/Frontend/Wisdom_expo/languages/es.json
+++ b/Frontend/Wisdom_expo/languages/es.json
@@ -119,6 +119,8 @@
     "confirm_new_password": "Confirmar nueva contraseña",
     "type_it_again": "Vuelve a escribirla",
     "safe_and_login": "Guardar e iniciar sesión",
+    "passwords_do_not_match": "Las contraseñas no coinciden.",
+    "reset_token_error": "Hubo un problema al restablecer tu contraseña.",
     "stay_informed": "Mantente informado",
     "notifications_subtitle": "Recibe información y recordatorios de tus servicios",
     "allow": "Permitir",

--- a/Frontend/Wisdom_expo/languages/fr.json
+++ b/Frontend/Wisdom_expo/languages/fr.json
@@ -119,6 +119,8 @@
     "confirm_new_password": "Confirmer le nouveau mot de passe",
     "type_it_again": "Retapez-le",
     "safe_and_login": "Enregistrer et se connecter",
+    "passwords_do_not_match": "Les mots de passe ne correspondent pas.",
+    "reset_token_error": "Un problème est survenu lors de la réinitialisation du mot de passe.",
     "stay_informed": "Restez informé",
     "notifications_subtitle": "Recevez des informations et des rappels sur vos services",
     "allow": "Autoriser",

--- a/Frontend/Wisdom_expo/languages/zh.json
+++ b/Frontend/Wisdom_expo/languages/zh.json
@@ -119,6 +119,8 @@
     "confirm_new_password": "确认新密码",
     "type_it_again": "再输入一次",
     "safe_and_login": "保存并登录",
+    "passwords_do_not_match": "两次密码不一致。",
+    "reset_token_error": "重置密码时出现问题。",
     "stay_informed": "保持知情",
     "notifications_subtitle": "接收有关您服务的信息和提醒",
     "allow": "允许",

--- a/Frontend/Wisdom_expo/screens/start/ForgotPassword.js
+++ b/Frontend/Wisdom_expo/screens/start/ForgotPassword.js
@@ -8,6 +8,7 @@ import '../../languages/i18n';
 import { useNavigation } from '@react-navigation/native';
 import {ChevronLeftIcon} from 'react-native-heroicons/outline';
 import WisdomLogo from '../../assets/wisdomLogo.tsx'
+import api from '../../utils/api';
 
 
 export default function ForgotPasswordScreen() {
@@ -25,13 +26,18 @@ export default function ForgotPasswordScreen() {
         setEmail (newEmail);
         setShowError(false);
       }
-    const nextPressed = () =>{
-    if (email.includes('@')){
-        navigation.navigate('EmailSended');
-    }
-    else{
+    const nextPressed = async () => {
+      if (email.length < 1) {
         setShowError(true);
-    }
+        return;
+      }
+      try {
+        await api.post('/api/forgot-password', { emailOrUsername: email });
+        navigation.navigate('EmailSended');
+      } catch (error) {
+        console.error('Forgot password error:', error);
+        setShowError(true);
+      }
     }
 
     return (


### PR DESCRIPTION
## Summary
- add backend endpoints for password reset emails and new passwords
- send password reset email using same branding as verification mail
- hook up ForgotPassword screen to call new API
- update NewPassword screen to use token and auto-login
- add translations for new error messages

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test` in Frontend (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_684eb77b5458832bbad94eb4ba16ad26